### PR TITLE
Fix unintentional deletion of /tmp

### DIFF
--- a/acme_nginx/client.py
+++ b/acme_nginx/client.py
@@ -236,7 +236,7 @@ def main():
             if directory:
                 print('{0} removing {1}'
                         .format(time.strftime("%b %d %H:%M:%S"), directory))
-                os.removedirs(directory)
+                os.rmdir(directory)
 
     def _log(message, exit_with_error=False):
         print('{0} {1}'.format(time.strftime("%b %d %H:%M:%S"), message))


### PR DESCRIPTION
os.removedirs removes all the parent directories as well. This leads to
/tmp being deleted on systems where it happens to be empty.