### PR TITLE
docs(usage): show correct flag for dns provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Now you can generate wildcard certificate
 ```
 sudo su -
 export API_TOKEN=yourDigitalOceanApiToken
-acme-nginx --dns digitalocean -d '*.example.com'
+acme-nginx --dns-provider digitalocean -d '*.example.com'
 ```
 
 ### Debug


### PR DESCRIPTION
this bit me my first run-through, then I noticed the difference for Route53.