### PR TITLE
Add support for BSD ps when getting nginx pid

### DIFF
--- a/acme_nginx/Acme.py
+++ b/acme_nginx/Acme.py
@@ -61,7 +61,8 @@ class Acme(object):
         self.dns_provider = dns_provider
         self.skip_nginx_reload = skip_nginx_reload
 
-    def _get_nginx_pid(self):
+    @staticmethod
+    def _get_nginx_pid():
         if platform.system() == "Linux":
             return max(map(int, subprocess.Popen(
                 'ps -o ppid= -C nginx'.split(),

--- a/acme_nginx/Acme.py
+++ b/acme_nginx/Acme.py
@@ -5,6 +5,7 @@ import binascii
 import hashlib
 import json
 import os
+import platform
 import subprocess
 import sys
 import tempfile
@@ -60,12 +61,22 @@ class Acme(object):
         self.dns_provider = dns_provider
         self.skip_nginx_reload = skip_nginx_reload
 
+    def _get_nginx_pid(self):
+        if platform.system() == "Linux":
+            return max(map(int, subprocess.Popen(
+                'ps -o ppid= -C nginx'.split(),
+                stdout=subprocess.PIPE).communicate()[0].split()))
+        else:
+            pl = subprocess.Popen(
+                'ps -ax -o ppid= -o command= -c'.split(),
+                stdout=subprocess.PIPE).communicate()[0].splitlines()
+            return max(map(int, [p.split()[0] for p in pl
+                                 if p.endswith(b'nginx')]))
+
     def _reload_nginx(self):
         """ Return nginx master process id and sends HUP to it """
         try:
-            m_pid = max(map(int, subprocess.Popen(
-                'ps -o ppid= -C nginx'.split(),
-                stdout=subprocess.PIPE).communicate()[0].split()))
+            m_pid = self._get_nginx_pid()
             self.log.info('killing nginx process {0} with HUP'.format(m_pid))
             os.kill(m_pid, 1)
         except ValueError:


### PR DESCRIPTION
This patch adds support for BSD-style `ps` when getting nginx pid. In particular this flavour of `ps` does not support process selection/filtering, so instead we do so manually.

Tested on FreeBSD 11 with Python 2.7 and 3.6.

Fixes #17.