### PR TITLE
Change generated CSR version to 0

### DIFF
--- a/acme_nginx/Acme.py
+++ b/acme_nginx/Acme.py
@@ -195,7 +195,7 @@ server {{
             key = fd.read()
         pk = OpenSSL.crypto.load_privatekey(OpenSSL.crypto.FILETYPE_PEM, key)
         req.set_pubkey(pk)
-        req.set_version(2)
+        req.set_version(0)
         req.sign(pk, "sha256")
         return OpenSSL.crypto.dump_certificate_request(
             OpenSSL.crypto.FILETYPE_ASN1, req


### PR DESCRIPTION
CSRs are PKCS#10 documents, and the standard does not define versions above 0.

Reference: certbot/certbot#9334