### PR TITLE
Fixed some warnings in Dockerfile from hadolint and docker build itself

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.11 AS build
 
 WORKDIR /opt
-RUN pip install pyinstaller
+RUN pip install --no-cache-dir pyinstaller
 COPY . /opt
 RUN pip wheel -r requirements.txt
-RUN pip install -r /opt/requirements.txt && \
+RUN pip install --no-cache-dir -r /opt/requirements.txt && \
     python setup.py install && \
     pyinstaller -sF ./acme-runner.py
 
@@ -14,7 +14,7 @@ FROM python:3.11-slim
 COPY --from=build /opt /opt
 
 WORKDIR /opt
-RUN pip install -r /opt/requirements.txt -f /opt && \
+RUN pip install --no-cache-dir -r /opt/requirements.txt -f /opt && \
     python setup.py install && \
     cp dist/acme-runner /usr/bin/ && \
     rm -rf /opt/* /root/.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11 as build
+FROM python:3.11 AS build
 
 WORKDIR /opt
 RUN pip install pyinstaller


### PR DESCRIPTION
I used hadolint and discovered following warnings:
```
hadolint < Dockerfile 
-:4 DL3013 warning: Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>` or `pip install --requirement <requirements file>`               
-:4 DL3042 warning: Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`
-:7 DL3042 warning: Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`
-:17 DL3042 warning: Avoid use of cache directory with pip. Use `pip install --no-cache-dir <package>`
```

I fixed all of them except of DL3013 on line 4, because I don't know which version of pyinstaller should be actually picked.

I did it, because I plan to use acme-nginx in the future from docker container.

Here is the link to hadolint and it's rules:
https://github.com/hadolint/hadolint?tab=readme-ov-file#rules